### PR TITLE
Accept nil player argument.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -27,7 +27,7 @@ minetest.register_node("bones:bones", {
 	
 	can_dig = function(pos, player)
 		local inv = minetest.env:get_meta(pos):get_inventory()
-		return is_owner(pos, player:get_player_name()) and inv:is_empty("main")
+		return player and is_owner(pos, player:get_player_name()) and inv:is_empty("main")
 	end,
 	
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)


### PR DESCRIPTION
When technic/technic/machines/HV/quarry.lua calls the bones:can_dig(),
it calls it with a nil player argument. That makes the server crash. I
patched quarry.lua to use the quarry owner's player object, but asl97
rejected the patch, saying:

"The api allows nil player, so it is a problem that the bone mod should
fix.  Also, if the player is offline, minetest.get_player_by_name would
return nil too."
